### PR TITLE
Make "help" the default command

### DIFF
--- a/urdfz/__main__.py
+++ b/urdfz/__main__.py
@@ -4,7 +4,7 @@ from typing_extensions import Annotated
 from .pack import make_urdfz_file
 from .unpack import unpack_urdfz_file
 
-cli = typer.Typer()
+cli = typer.Typer(no_args_is_help=True)
 
 
 @cli.command()


### PR DESCRIPTION
Without this, typing `urdfz` just gives you an unhelpful "missing
command" message. With this, it shows you the help text.

Closes #12
