### PR TITLE
Use Path annotations in CLI commands

### DIFF
--- a/pack_test.py
+++ b/pack_test.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 def test_read_file_to_str():
     with patch("builtins.open", mock_open(read_data="data")) as mock_file:  # pyright: ignore[reportAny]
-        assert read_file_to_str("path/to/my/file") == "data"
-        mock_file.assert_called_with("path/to/my/file", "r")  # pyright: ignore[reportAny]
+        assert read_file_to_str(Path("path/to/my/file")) == "data"
+        mock_file.assert_called_with(Path("path/to/my/file"), "r")  # pyright: ignore[reportAny]
     with patch("builtins.open", mock_open(read_data="data2")) as mock_file:  # pyright: ignore[reportAny]
         path = Path("path/to/my/file2")
         assert read_file_to_str(path) == "data2"

--- a/urdfz/__main__.py
+++ b/urdfz/__main__.py
@@ -1,5 +1,6 @@
 import typer
 from typing_extensions import Annotated
+from pathlib import Path
 
 from .pack import make_urdfz_file
 from .unpack import unpack_urdfz_file
@@ -9,7 +10,9 @@ cli = typer.Typer(no_args_is_help=True)
 
 @cli.command()
 def pack(
-    path: Annotated[str, typer.Argument(help="The path to the URDF file to pack")],
+    path: Annotated[
+        Path, typer.Argument(help="The path to the URDF file to pack", exists=True)
+    ],
 ):
     """Packs a URDF and all its assets into a URDFZ file."""
     make_urdfz_file(path)
@@ -17,7 +20,9 @@ def pack(
 
 @cli.command()
 def unpack(
-    path: Annotated[str, typer.Argument(help="The path to the URDFZ file to unpack")],
+    path: Annotated[
+        Path, typer.Argument(help="The path to the URDFZ file to unpack", exists=True)
+    ],
 ):
     """Unpacks a URDFZ into its component URDF file and assets."""
     unpack_urdfz_file(path)

--- a/urdfz/pack.py
+++ b/urdfz/pack.py
@@ -17,14 +17,14 @@ except ImportError:
         )
 
 
-def make_urdfz_file(urdf_path: str):
+def make_urdfz_file(urdf_path: Path):
     urdf = parse_urdf(read_file_to_str(urdf_path))
     meshes = get_meshes(urdf)
     with tempfile.TemporaryDirectory() as staging_directory:
         staging_directory = Path(staging_directory)
         copy_assets_to_staging_directory(get_mesh_filenames(meshes), staging_directory)
         rewrite_mesh_filenames(meshes)
-        ET.ElementTree(urdf).write(staging_directory / Path(urdf_path).name)
+        ET.ElementTree(urdf).write(staging_directory / urdf_path.name)
         # Create a second temporary directory to hold the archive while it's still a ".zip" file before it gets renamed to ".urdfz" so we don't confuse ourselves by putting files into the directory we're compressing
         with tempfile.TemporaryDirectory() as archive_temporary_directory:
             archive_temporary_directory = Path(archive_temporary_directory)
@@ -34,7 +34,7 @@ def make_urdfz_file(urdf_path: str):
                     "zip",
                     staging_directory,
                 ),
-                Path(urdf_path).with_suffix(".urdfz"),
+                urdf_path.with_suffix(".urdfz"),
             )
 
 

--- a/urdfz/unpack.py
+++ b/urdfz/unpack.py
@@ -6,10 +6,8 @@ import zipfile
 from .urdf_utils import read_file_to_str, parse_urdf, get_meshes
 
 
-def unpack_urdfz_file(urdfz_path: str | Path, output_dir: str | Path | None = None):
+def unpack_urdfz_file(urdfz_path: Path, output_dir: Path | None = None):
     """Unpack a URDFZ file to a directory named after the URDFZ file"""
-    urdfz_path = Path(urdfz_path)
-
     # Create output directory based on URDFZ filename if not specified
     if output_dir is None:
         output_dir = Path(urdfz_path.stem)  # Remove .urdfz extension

--- a/urdfz/urdf_utils.py
+++ b/urdfz/urdf_utils.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 ET.register_namespace("", "http://www.ros.org")
 
 
-def read_file_to_str(path: Path | str) -> str:
+def read_file_to_str(path: Path) -> str:
     """Read a file and return its contents as a string"""
     with open(path, "r") as f:
         return f.read()


### PR DESCRIPTION
This gets us path-existence checks for free!

And makes the code a bit more sane so we don't have to deal with `str`
or `Path` all over the place like the Python standard library does.
