### PR TITLE
`ament-index-python` -> `resolve-robotics-uri`

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -77,6 +77,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/2c/d5c234ff2fd2b7668c7c710f638cb02214375475744d135b2cab572a0cd3/resolve_robotics_uri_py-0.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/06/8deb52d48a9a624fd37390555d9589e719eac568c020b27e96eed671f25f/ruff-0.12.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
@@ -152,6 +153,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/2c/d5c234ff2fd2b7668c7c710f638cb02214375475744d135b2cab572a0cd3/resolve_robotics_uri_py-0.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/03/6816b2ed08836be272e87107d905f0908be5b4a40c14bfc91043e76631b8/ruff-0.12.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
@@ -224,6 +226,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/2c/d5c234ff2fd2b7668c7c710f638cb02214375475744d135b2cab572a0cd3/resolve_robotics_uri_py-0.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/60/d1e335417804df452589271818749d061b22772b87efda88354cf35cdb7a/ruff-0.12.12-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
@@ -1433,6 +1436,16 @@ packages:
   purls: []
   size: 291806
   timestamp: 1740380591358
+- pypi: https://files.pythonhosted.org/packages/97/2c/d5c234ff2fd2b7668c7c710f638cb02214375475744d135b2cab572a0cd3/resolve_robotics_uri_py-0.3.1-py3-none-any.whl
+  name: resolve-robotics-uri-py
+  version: 0.3.1
+  sha256: 1bcdce086f84a7455d2894fde34714fd3c178960fc2308ca476193ad22d61625
+  requires_dist:
+  - black ; extra == 'style'
+  - isort ; extra == 'style'
+  - black ; extra == 'all'
+  - isort ; extra == 'all'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl
   name: rich
   version: 14.2.0
@@ -2615,9 +2628,10 @@ packages:
 - pypi: ./
   name: urdfz
   version: 0.2.0
-  sha256: cf31b2bcf871f5dbdd41c0e96d1ce352a9a736d589a0d8f3d2e0bc2d31814a12
+  sha256: 816433653dcd2937874e6a10ad2ad4c990a789ddfd5378d764d906caaf4774ba
   requires_dist:
   - typer>=0.20.0,<0.21
+  - resolve-robotics-uri-py>=0.3.1,<0.4.0
   - pytest>=8.4.1,<9 ; extra == 'dev'
   - ruff>=0.12.8,<0.13 ; extra == 'dev'
   - basedpyright>=1.32.1,<2 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 description = "Self-contained, portable, actually UNIFIED Robot Description Files (URDFs)"
 dependencies = [
     "typer>=0.20.0,<0.21",
+    "resolve-robotics-uri-py>=0.3.1,<0.4.0"
 ]
 
 [project.optional-dependencies]
@@ -33,7 +34,6 @@ test = "pytest **/*_test.py"
 lint = "ruff format --check && ruff check && basedpyright ."
 
 [tool.pixi.dependencies]
-ros-humble-ament-index-python = ">=1.4.0,<2"
 ros-humble-turtlebot3-description = ">=2.3.1,<3"
 
 [tool.pixi.pypi-dependencies]


### PR DESCRIPTION
Remove the project's dependency on ROS by instead relying on
@traversaro's team's resolver for the `file://`, `model://`,
and `package://` URI schemes. Thanks Silvio et al!

Closes #15
